### PR TITLE
Feature/config via args

### DIFF
--- a/common/requests_client.py
+++ b/common/requests_client.py
@@ -1,4 +1,5 @@
 import requests
+import logging
 from urllib.parse import urlencode
 
 #Essa classe é responsável por fazer as requisições e retornar as respostas
@@ -24,7 +25,7 @@ class RequestsClient:
         # Para debug, mostra a URL completa:
         query_string = urlencode(self.params)
         full_url = f"{url}?{query_string}"
-        print(f"Full URL: {full_url}")
+        logging.info(f"Full URL: {full_url}")
 
         response = requests.get(url, params=self.params)
         response.raise_for_status()

--- a/plugins/taps/tap_openmeteo/tap_openmeteo/singer/openmeteo_singer.py
+++ b/plugins/taps/tap_openmeteo/tap_openmeteo/singer/openmeteo_singer.py
@@ -12,7 +12,6 @@ class OpenMeteoSingerRunner:
     def run(self):
         # 1. Extrai payload
         data = self.extractor.extract()
-        logging.info(data)
 
         # 2. Extrai todas as listas do bloco "hourly"
         hourly_data = data["hourly"]


### PR DESCRIPTION
As funções click foram removidas, agora capturamos o config e demais flags via argparse em conjunto com a bib utils do singer (metodo parse_args)

No meltano.yml temos o atributo settings da nossa tap.
Ee indica que o config vai assumir o valor da variável de ambiente $CONFIG_B64 (.env)
Dessa forma, capturamos o valor da variavel de ambiente usando o parse_args da utils do singer. Esse método vai transformar meu config num json e utiliza-lo no meu código

Para as flags utilizamos o ArgumentParser para adicionar os argumetos das nossas flags about, discover e test-request, depois usamos o  sys.argv para remove-los da lista passada na linha de comando evitando conflitos com o utils do singer.
